### PR TITLE
Alternative cropper preview widget

### DIFF
--- a/src/main/java/com/google/code/gwt/crop/client/GWTConstrainedCropperPreview.java
+++ b/src/main/java/com/google/code/gwt/crop/client/GWTConstrainedCropperPreview.java
@@ -1,0 +1,88 @@
+package com.google.code.gwt.crop.client;
+
+import com.google.gwt.dom.client.Style.Overflow;
+import com.google.gwt.dom.client.Style.Position;
+import com.google.gwt.dom.client.Style.Unit;
+import com.google.gwt.uibinder.client.UiConstructor;
+import com.google.gwt.user.client.ui.Image;
+import com.google.gwt.user.client.ui.SimplePanel;
+
+/**
+ * <p>
+ * <b>GWTConstrainedCropperPreview</b> - widget that previews the selected area
+ * in a panel whose size won't exceed the given dimensions.
+ * </p>
+ * 
+ * @author Timo Hoepfner
+ */
+public class GWTConstrainedCropperPreview extends SimplePanel implements IGWTCropperPreview {
+  private int maxWidth, maxHeight, canvasWidth, canvasHeight;
+  private Image image;
+
+  /**
+   * Initiates the preview widget.
+   * 
+   * <p>
+   * Usage example: <code>new GWTConstrainedCropperPreview(100, 100)</code>
+   * constructs a preview, that will scale both horizontally and vertically, 
+   * but never exceed 100px in either dimension.
+   * </p>
+   * 
+   * <ul>
+   *    <li>For a square selection, both width and height are 100px.</li>
+   *    <li>For a landscape selection, the width is 100px and height is less than 100px.</li>
+   *    <li>For a portrait selection, the height is 100px and width is less than 100px.</li>
+   * </ul>
+   * 
+   * @param maxWidth
+   *          - maximum width in px
+   * @param maxHeight
+   *          - maximum height in px
+   */
+  @UiConstructor
+  public GWTConstrainedCropperPreview(int maxWidth, int maxHeight) {
+    this.maxWidth = maxWidth;
+    this.maxHeight = maxHeight;
+
+    getElement().getStyle().setPosition(Position.RELATIVE);
+    getElement().getStyle().setOverflow(Overflow.HIDDEN);
+  }
+
+  public void init(String imageUrl, int canvasWidth, int canvasHeight, double aspectRatio) {
+    this.canvasWidth = canvasWidth;
+    this.canvasHeight = canvasHeight;
+
+    image = new Image(imageUrl);
+    image.getElement().getStyle().setPosition(Position.ABSOLUTE);
+
+    add(image);
+  }
+
+  public void updatePreview(int selectionWidth, int selectionHeight, int cropLeft, int cropTop) {
+    double selectionRatio = (double) selectionWidth / selectionHeight;
+    double containerRatio = (double) maxWidth / maxHeight;
+
+    double scale = selectionRatio < containerRatio
+        ? (double) selectionHeight / maxHeight
+        : (double) selectionWidth / maxWidth;
+
+    int containerWidth = (int) (selectionWidth / scale);
+    int containerHeight = (int) (selectionHeight / scale);
+
+    setPixelSize(containerWidth, containerHeight);
+
+    double dimensionRatioX = (double) canvasWidth / selectionWidth;
+    double dimensionRatioY = (double) canvasHeight / selectionHeight;
+    double positionRatioX = (double) selectionWidth / containerWidth;
+    double positionRatioY = (double) selectionHeight / containerHeight;
+
+    int imageWidth = (int) (containerWidth * dimensionRatioX);
+    int imageHeight = (int) (containerHeight * dimensionRatioY);
+    int imageLeft = (int) -(cropLeft / positionRatioX);
+    int imageTop = (int) -(cropTop / positionRatioY);
+
+    image.setPixelSize(imageWidth, imageHeight);
+    image.getElement().getStyle().setLeft(imageLeft, Unit.PX);
+    image.getElement().getStyle().setTop(imageTop, Unit.PX);
+  }
+}

--- a/src/main/java/com/google/code/gwt/crop/client/GWTCropper.java
+++ b/src/main/java/com/google/code/gwt/crop/client/GWTCropper.java
@@ -102,7 +102,7 @@ public class GWTCropper extends HTMLPanel implements MouseMoveHandler, MouseUpHa
 	private int MIN_WIDTH = this.HANDLE_SIZE;
 	private int MIN_HEIGHT = this.HANDLE_SIZE;
 	
-	private GWTCropperPreview previewWidget;
+	private IGWTCropperPreview previewWidget;
 	
 	private AbsolutePanelImpl selectionContainer = new AbsolutePanelImpl();
 
@@ -369,7 +369,7 @@ public class GWTCropper extends HTMLPanel implements MouseMoveHandler, MouseUpHa
 	 * 
 	 * @param previewWidget
 	 */
-    public void registerPreviewWidget(GWTCropperPreview previewWidget){
+    public void registerPreviewWidget(IGWTCropperPreview previewWidget){
         this.previewWidget = previewWidget;
     };
 	

--- a/src/main/java/com/google/code/gwt/crop/client/GWTCropperPreview.java
+++ b/src/main/java/com/google/code/gwt/crop/client/GWTCropperPreview.java
@@ -17,7 +17,7 @@ import com.google.gwt.user.client.ui.SimplePanel;
  * @since 0.5.0
  * @version %I%, %G%
  */
-public class GWTCropperPreview extends SimplePanel {
+public class GWTCropperPreview extends SimplePanel implements IGWTCropperPreview {
 
     /**Because crop image can be scaled. We have to remember its width and height
      * to future recounting */
@@ -93,7 +93,7 @@ public class GWTCropperPreview extends SimplePanel {
      * @param canvasHeight
      * @param aspectRatio
      */
-    void init(String imageUrl, int canvasWidth, int canvasHeight, double aspectRatio) {
+    public void init(String imageUrl, int canvasWidth, int canvasHeight, double aspectRatio) {
         this.embeddedImage = new Image(imageUrl);
         
         this.cropCanvasWidth = canvasWidth;
@@ -118,7 +118,7 @@ public class GWTCropperPreview extends SimplePanel {
      * @param cropLeft
      * @param cropTop
      */
-    void updatePreview(int cropShapeWidth, int cropShapeHeight, int cropLeft, int cropTop) {
+    public void updatePreview(int cropShapeWidth, int cropShapeHeight, int cropLeft, int cropTop) {
 
         switch (this.fixedSide) {
             case WIDTH:

--- a/src/main/java/com/google/code/gwt/crop/client/IGWTCropperPreview.java
+++ b/src/main/java/com/google/code/gwt/crop/client/IGWTCropperPreview.java
@@ -1,0 +1,26 @@
+package com.google.code.gwt.crop.client;
+
+public interface IGWTCropperPreview {
+
+  /**
+   * GWTCropper calls this method after the image is loaded 
+   * and all dimensions are known.
+   * 
+   * @param imageUrl - image URL for preview
+   * @param canvasWidth
+   * @param canvasHeight
+   * @param aspectRatio
+   */
+  void init(String imageUrl, int canvasWidth, int canvasHeight, double aspectRatio);
+
+  /**
+   * GWTCropper calls this method whenever the selected area changes.
+   * 
+   * @param cropShapeWidth
+   * @param cropShapeHeight
+   * @param cropLeft
+   * @param cropTop
+   */
+  void updatePreview(int cropShapeWidth, int cropShapeHeight, int cropLeft, int cropTop);
+
+}


### PR DESCRIPTION
Alternative cropper preview widget that is constrained both horizontally and vertically.

Example: `new GWTConstrainedCropperPreview(100, 100)` constructs a preview, that scales both horizontally and vertically, but doesn't exceed 100px in either dimension.

- For a square selection, both width and height are 100px.
- For a landscape selection, the width is 100px and height is less than 100px.
- For a portrait selection, the height is 100px and width is less than 100px.
