### PR TITLE
add GWTCropper.setWidth(int)

### DIFF
--- a/src/main/java/com/google/code/gwt/crop/client/GWTCropper.java
+++ b/src/main/java/com/google/code/gwt/crop/client/GWTCropper.java
@@ -108,7 +108,8 @@ public class GWTCropper extends HTMLPanel implements MouseMoveHandler, MouseUpHa
 
 	// used by UIBuinder
 	private final String imageURL;
-	private double proportion;
+	private double imageAspectRatio;
+	private double proportion = 1;
 
 	/**
 	 * Constructor with mandatory parameter of image's URL.
@@ -187,7 +188,7 @@ public class GWTCropper extends HTMLPanel implements MouseMoveHandler, MouseUpHa
 	 * @return X coordinate
 	 */
 	public int getSelectionXCoordinate() {
-		return (this.nInnerX + this.SELECTION_BORDER_SIZE);
+		return (int) ((this.nInnerX + this.SELECTION_BORDER_SIZE) * proportion);
 	}
 	
 	/**
@@ -200,7 +201,7 @@ public class GWTCropper extends HTMLPanel implements MouseMoveHandler, MouseUpHa
 	 * @return Y coordinate
 	 */
 	public int getSelectionYCoordinate() {
-		return (this.nInnerY + this.SELECTION_BORDER_SIZE);
+		return (int) ((this.nInnerY + this.SELECTION_BORDER_SIZE) * proportion);
 	}
 	
 	/**
@@ -213,7 +214,7 @@ public class GWTCropper extends HTMLPanel implements MouseMoveHandler, MouseUpHa
 	 * @return width in pixels
 	 */
 	public int getSelectionWidth() {
-		return this.nInnerWidth;
+		return (int) (this.nInnerWidth * proportion);
 	}
 	
 	/**
@@ -225,7 +226,7 @@ public class GWTCropper extends HTMLPanel implements MouseMoveHandler, MouseUpHa
 	 * @return height in pixels
 	 */
 	public int getSelectionHeight() {
-		return this.nInnerHeight;
+		return (int) (this.nInnerHeight * proportion);
 	}
 	
 	/**
@@ -422,13 +423,14 @@ public class GWTCropper extends HTMLPanel implements MouseMoveHandler, MouseUpHa
 	            
 				// get original image size
 				if (nOuterWidth != -1 || nOuterHeight != -1) {
-					proportion = (double) image.getWidth()/image.getHeight();
-					if (nOuterWidth == -1) nOuterWidth = (int) (nOuterHeight*proportion);
-					if (nOuterHeight == -1) nOuterHeight = (int) (nOuterWidth/proportion);
+					imageAspectRatio = (double) image.getWidth()/image.getHeight();
+					if (nOuterWidth == -1) nOuterWidth = (int) (nOuterHeight * imageAspectRatio);
+					if (nOuterHeight == -1) nOuterHeight = (int) (nOuterWidth / imageAspectRatio);
 				} else {
 					nOuterWidth = image.getWidth();
 					nOuterHeight = image.getHeight();
 				}
+				proportion = (double) image.getWidth() / nOuterWidth;
 				
 				DOM.setElementProperty(image.getElement(), "width", nOuterWidth + "");
 				DOM.setElementProperty(image.getElement(), "height", nOuterHeight + "");
@@ -1029,11 +1031,11 @@ public class GWTCropper extends HTMLPanel implements MouseMoveHandler, MouseUpHa
 	 */
 	private void updatePreviewWidget() {
 		if (previewWidget != null) {
-		    previewWidget.updatePreview(
-		    		this.getSelectionWidth(),
-		    		this.getSelectionHeight(), 
-		    		this.getSelectionXCoordinate(),
-		    		this.getSelectionYCoordinate());
+			previewWidget.updatePreview(
+					(int) (this.getSelectionWidth() / proportion),
+					(int) (this.getSelectionHeight() / proportion),
+					(int) (this.getSelectionXCoordinate() / proportion),
+					(int) (this.getSelectionYCoordinate() / proportion));
 		}
 	}
 	

--- a/src/main/java/com/google/code/gwt/crop/client/GWTCropper.java
+++ b/src/main/java/com/google/code/gwt/crop/client/GWTCropper.java
@@ -108,6 +108,7 @@ public class GWTCropper extends HTMLPanel implements MouseMoveHandler, MouseUpHa
 
 	// used by UIBuinder
 	private final String imageURL;
+	private double proportion;
 
 	/**
 	 * Constructor with mandatory parameter of image's URL.
@@ -347,7 +348,32 @@ public class GWTCropper extends HTMLPanel implements MouseMoveHandler, MouseUpHa
 		this.nOuterHeight = height;
 	};
 	
-	
+	/**
+	 * Sets the cropper's width, height will computed with keeping image aspect ratio.
+	 *
+	 * @param width integer in px
+	 */
+	public void setWidth(int width) {
+		super.setWidth(width+"px");
+		nOuterWidth = width;
+	}
+
+	/**
+	 * <i><b>Deprecated.</b> This method sets the width only for parent element, but not for the whole widget.
+	 * Use method {@link com.google.code.gwt.crop.client.GWTCropper#setWidth(int)} instead.</i>
+	 *
+	 * <p />
+	 *
+	 * {@inheritDoc}
+	 *
+	 * @see com.google.gwt.user.client.ui.UIObject#setWidth(String)
+	 */
+	@Override
+	@Deprecated
+	public void setWidth(String width) {
+		super.setWidth(width);
+	}
+
 	/**
 	 * <i><b>Deprecated.</b> This method sets the size only for parent element, but not for the whole widget.
 	 * Use method {@link com.google.code.gwt.crop.client.GWTCropper#setSize(int, int) setSize(int width, int height)} instead.</i>
@@ -395,8 +421,14 @@ public class GWTCropper extends HTMLPanel implements MouseMoveHandler, MouseUpHa
 	            image.getElement().getStyle().setProperty("maxWidth","none");
 	            
 				// get original image size
-				if (nOuterWidth == -1) nOuterWidth = image.getWidth();
-				if (nOuterHeight == -1) nOuterHeight = image.getHeight();
+				if (nOuterWidth != -1 || nOuterHeight != -1) {
+					proportion = (double) image.getWidth()/image.getHeight();
+					if (nOuterWidth == -1) nOuterWidth = (int) (nOuterHeight*proportion);
+					if (nOuterHeight == -1) nOuterHeight = (int) (nOuterWidth/proportion);
+				} else {
+					nOuterWidth = image.getWidth();
+					nOuterHeight = image.getHeight();
+				}
 				
 				DOM.setElementProperty(image.getElement(), "width", nOuterWidth + "");
 				DOM.setElementProperty(image.getElement(), "height", nOuterHeight + "");


### PR DESCRIPTION
Now you can set width of cropper with keeping image aspect ratio. In case of setSize orginal image aspect ratio does not respect.

It looks like:
![image](https://cloud.githubusercontent.com/assets/1183619/9066989/67b1de9e-3ae3-11e5-9067-b0173d2d1eae.png)
and 
![image](https://cloud.githubusercontent.com/assets/1183619/9067006/98540626-3ae3-11e5-862f-dc74347f86d7.png)

