### PR TITLE
Fix for selection off by 1px

### DIFF
--- a/src/main/java/com/google/code/gwt/crop/client/GWTCropper.java
+++ b/src/main/java/com/google/code/gwt/crop/client/GWTCropper.java
@@ -189,7 +189,7 @@ public class GWTCropper extends HTMLPanel implements MouseMoveHandler, MouseUpHa
      * @return X coordinate
      */
     public int getSelectionXCoordinate() {
-        return (int) ((this.nInnerX + this.SELECTION_BORDER_SIZE) * proportion);
+        return (int) (this.nInnerX * proportion);
     }
 
     /**
@@ -202,7 +202,7 @@ public class GWTCropper extends HTMLPanel implements MouseMoveHandler, MouseUpHa
      * @return Y coordinate
      */
     public int getSelectionYCoordinate() {
-        return (int) ((this.nInnerY + this.SELECTION_BORDER_SIZE) * proportion);
+        return (int) (this.nInnerY * proportion);
     }
 
     /**
@@ -671,10 +671,10 @@ public class GWTCropper extends HTMLPanel implements MouseMoveHandler, MouseUpHa
                 this.nInnerY = cursorY - offsetY;
 
                 // don't drag selection out of the canvas borders
-                if (this.nInnerX < -SELECTION_BORDER_SIZE) this.nInnerX = -SELECTION_BORDER_SIZE;
-                if (this.nInnerY < -SELECTION_BORDER_SIZE) this.nInnerY = -SELECTION_BORDER_SIZE;
-                if (this.nInnerX + this.nInnerWidth > this.nOuterWidth + SELECTION_BORDER_SIZE) this.nInnerX = this.nOuterWidth - this.nInnerWidth + SELECTION_BORDER_SIZE;
-                if (this.nInnerY + this.nInnerHeight > this.nOuterHeight + SELECTION_BORDER_SIZE) this.nInnerY = this.nOuterHeight - this.nInnerHeight + SELECTION_BORDER_SIZE;
+                if (this.nInnerX < 0) this.nInnerX = 0;
+                if (this.nInnerY < 0) this.nInnerY = 0;
+                if (this.nInnerX + this.nInnerWidth > this.nOuterWidth) this.nInnerX = this.nOuterWidth - this.nInnerWidth;
+                if (this.nInnerY + this.nInnerHeight > this.nOuterHeight) this.nInnerY = this.nOuterHeight - this.nInnerHeight;
 
                 elH.getStyle().setLeft(this.nInnerX, Unit.PX);
                 elH.getStyle().setTop(this.nInnerY, Unit.PX);

--- a/src/main/java/com/google/code/gwt/crop/client/GWTCropper.java
+++ b/src/main/java/com/google/code/gwt/crop/client/GWTCropper.java
@@ -486,8 +486,8 @@ public class GWTCropper extends HTMLPanel implements MouseMoveHandler, MouseUpHa
             imgSelectionBg.getElement().getStyle().setPropertyPx("maxHeight", nOuterHeight);
         }
 
-        selectionContainer.add(imgSelectionBg, -this.nInnerX - 1,  -this.nInnerY - 1);
-        this._container.add(selectionContainer, this.nInnerX, this.nInnerY);
+        selectionContainer.add(imgSelectionBg, -this.nInnerX,  -this.nInnerY);
+        this._container.add(selectionContainer, this.nInnerX - SELECTION_BORDER_SIZE, this.nInnerY - SELECTION_BORDER_SIZE);
 
         this.buildSelectionArea();
 
@@ -680,12 +680,12 @@ public class GWTCropper extends HTMLPanel implements MouseMoveHandler, MouseUpHa
                 elH.getStyle().setTop(this.nInnerY, Unit.PX);
 
                 elS = this.selectionContainer.getElement();
-                elS.getStyle().setLeft(this.nInnerX, Unit.PX);
-                elS.getStyle().setTop(this.nInnerY, Unit.PX);
+                elS.getStyle().setLeft(this.nInnerX - SELECTION_BORDER_SIZE, Unit.PX);
+                elS.getStyle().setTop(this.nInnerY - SELECTION_BORDER_SIZE, Unit.PX);
 
                 elImg = ((Image) this.selectionContainer.getWidget(0)).getElement();
-                elImg.getStyle().setLeft(-this.nInnerX - SELECTION_BORDER_SIZE, Unit.PX);
-                elImg.getStyle().setTop(-this.nInnerY - SELECTION_BORDER_SIZE, Unit.PX);
+                elImg.getStyle().setLeft(-this.nInnerX, Unit.PX);
+                elImg.getStyle().setTop(-this.nInnerY, Unit.PX);
                 break;
 
 
@@ -752,14 +752,14 @@ public class GWTCropper extends HTMLPanel implements MouseMoveHandler, MouseUpHa
                 elH.getStyle().setHeight(nInnerHeight, Unit.PX);
 
                 elS = this.selectionContainer.getElement();
-                elS.getStyle().setLeft(this.nInnerX, Unit.PX);
-                elS.getStyle().setTop(this.nInnerY, Unit.PX);
+                elS.getStyle().setLeft(this.nInnerX - SELECTION_BORDER_SIZE, Unit.PX);
+                elS.getStyle().setTop(this.nInnerY - SELECTION_BORDER_SIZE, Unit.PX);
                 elS.getStyle().setWidth(nInnerWidth, Unit.PX);
                 elS.getStyle().setHeight(nInnerHeight, Unit.PX);
 
                 elImg = ((Image) this.selectionContainer.getWidget(0)).getElement();
-                elImg.getStyle().setLeft(-this.nInnerX - 1, Unit.PX);
-                elImg.getStyle().setTop(-this.nInnerY - 1, Unit.PX);
+                elImg.getStyle().setLeft(-this.nInnerX, Unit.PX);
+                elImg.getStyle().setTop(-this.nInnerY, Unit.PX);
 
                 Element el3 = this.draggableBackground.getElement();
                 el3.getStyle().setWidth(nInnerWidth, Unit.PX);
@@ -824,17 +824,17 @@ public class GWTCropper extends HTMLPanel implements MouseMoveHandler, MouseUpHa
 
                 elH = this.handlesContainer.getElement();
 
-                elH.getStyle().setTop(cursorY, Unit.PX);
+                elH.getStyle().setTop(nInnerY, Unit.PX);
                 elH.getStyle().setWidth(nInnerWidth, Unit.PX);
                 elH.getStyle().setHeight(nInnerHeight, Unit.PX);
 
                 elS = this.selectionContainer.getElement();
-                elS.getStyle().setTop(cursorY, Unit.PX);
+                elS.getStyle().setTop(nInnerY - SELECTION_BORDER_SIZE, Unit.PX);
                 elS.getStyle().setWidth(nInnerWidth, Unit.PX);
                 elS.getStyle().setHeight(nInnerHeight, Unit.PX);
 
                 elImg = ((Image) this.selectionContainer.getWidget(0)).getElement();
-                elImg.getStyle().setTop(-cursorY - 1, Unit.PX);
+                elImg.getStyle().setTop(-nInnerY, Unit.PX);
 
                 el3 = this.draggableBackground.getElement();
                 el3.getStyle().setWidth(nInnerWidth, Unit.PX);
@@ -900,17 +900,17 @@ public class GWTCropper extends HTMLPanel implements MouseMoveHandler, MouseUpHa
 
                 elH = this.handlesContainer.getElement();
 
-                elH.getStyle().setLeft(cursorX, Unit.PX);
+                elH.getStyle().setLeft(nInnerX, Unit.PX);
                 elH.getStyle().setWidth(nInnerWidth, Unit.PX);
                 elH.getStyle().setHeight(nInnerHeight, Unit.PX);
 
                 elS = this.selectionContainer.getElement();
-                elS.getStyle().setLeft(cursorX, Unit.PX);
+                elS.getStyle().setLeft(nInnerX - SELECTION_BORDER_SIZE, Unit.PX);
                 elS.getStyle().setWidth(nInnerWidth, Unit.PX);
                 elS.getStyle().setHeight(nInnerHeight, Unit.PX);
 
                 elImg = ((Image) this.selectionContainer.getWidget(0)).getElement();
-                elImg.getStyle().setLeft(-cursorX - 1, Unit.PX);
+                elImg.getStyle().setLeft(-nInnerX, Unit.PX);
 
                 el3 = this.draggableBackground.getElement();
                 el3.getStyle().setWidth(nInnerWidth, Unit.PX);


### PR DESCRIPTION
Currently, it's possible to create a selection that extends across the borders of the canvas by one pixel. See attached screenshot of the official demo below, where the image to be cropped is 600x398px and the selection is 601x399px, which shouldn't be possible.

Also, `getSelectionXCoordinate()` basically returns `nInnerX + SELECTION_BORDER_SIZE`, but `setInitialSelection(...)` doesn't take `SELECTION_BORDER_SIZE` into account. So, when you e.g. create a selection that covers the whole image and later open the cropper again setting the initial selection, the coordinates are deemed wrong by the cropper and it will reset the selection.

While trying to fix this, I found that the code introduced for issue #18 makes it quite complicated to get this right. That's why in this pull request, the internal coordinates are made zero based again and a different approach is taken to compensate for the border width.

![cropper](https://cloud.githubusercontent.com/assets/77366/9275603/82ba20b2-429e-11e5-98bd-b0c2cc6c20bd.jpg)
