### PR TITLE
Fix coordinate correction on MouseOut

### DIFF
--- a/src/main/java/com/google/code/gwt/crop/client/GWTCropper.java
+++ b/src/main/java/com/google/code/gwt/crop/client/GWTCropper.java
@@ -1112,7 +1112,7 @@ public class GWTCropper extends HTMLPanel implements MouseMoveHandler, MouseUpHa
         if (x < 0) x = 0;
         if (x > this.nOuterWidth) x = this.nOuterWidth;
         if (y < 0) y = 0;
-        if (y > this.nOuterHeight) x = this.nOuterHeight;
+        if (y > this.nOuterHeight) y = this.nOuterHeight;
 
         this.provideDragging(x, y);
 


### PR DESCRIPTION
Coordinate correction on MouseOut was updating the wrong variable when height was exceeded.

IMHO this should fix issue #25 
